### PR TITLE
Call with python3.

### DIFF
--- a/HocrConverter.py
+++ b/HocrConverter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """HocrConverter
 
 Convert Files from hOCR to pdf


### PR DESCRIPTION
Commit 33b572536d4cc619cae9d387e5d7f4ff8bdaadb8
makes it clear that the script should be called
using python3.

Most Linux distributions use python as a synonym
for python2. Explicitely call python3 on such
systems.